### PR TITLE
67 bullet

### DIFF
--- a/app/models/bullet.js
+++ b/app/models/bullet.js
@@ -12,7 +12,6 @@ class Bullet {
 			this.strike = false;
 			this.collections = [];
 		} else {
-			// if (!this.id) this.id = new Date().toISOString();
 			if (!this.strike) this.strike = false;
 			if (!this.collections) this.collections = [];
 			_.extend(this, content);

--- a/app/models/bullet.js
+++ b/app/models/bullet.js
@@ -12,7 +12,7 @@ class Bullet {
 			this.strike = false;
 			this.collections = [];
 		} else {
-			if (!this.id) this.id = new Date().toISOString();
+			// if (!this.id) this.id = new Date().toISOString();
 			if (!this.strike) this.strike = false;
 			if (!this.collections) this.collections = [];
 			_.extend(this, content);

--- a/app/models/collection.js
+++ b/app/models/collection.js
@@ -33,8 +33,7 @@ class Collection {
     deserializeBullets(bulletInstances) {
         this.bullets = this.bullets.map(bulletId => {
             let bullet = bulletInstances.find(b => b.id === bulletId);
-            bullet = new Bullet[bullet.type](bullet);
-            return bullet;
+            return new Bullet[bullet.type](bullet);
         });
         return this;
     }
@@ -46,9 +45,9 @@ class Collection {
     }
 
     addBullet(bullet) {
-        bullet = new Bullet[bullet.type](bullet) //this attaches id if needed
-        console.log(bullet, this.bullets);
-        if (this.bullets.find(b => b.id === bullet.id)) return; // make sure to check this!
+        bullet.id = bullet.id || new Date().toISOString();
+        // bullet = new Bullet[bullet.type](bullet) //this attaches id if needed
+        if (this.bullets.find(b => b.id === bullet.id)) return;
         this.bullets.push(bullet);
         bullet.collections.push(this.id);
         //add to other collections check

--- a/app/models/collection.js
+++ b/app/models/collection.js
@@ -46,7 +46,6 @@ class Collection {
 
     addBullet(bullet) {
         bullet.id = bullet.id || new Date().toISOString();
-        // bullet = new Bullet[bullet.type](bullet) //this attaches id if needed
         if (this.bullets.find(b => b.id === bullet.id)) return;
         this.bullets.push(bullet);
         bullet.collections.push(this.id);

--- a/app/models/collection.js
+++ b/app/models/collection.js
@@ -47,7 +47,7 @@ class Collection {
     addBullet(bullet, index) {
         bullet = new Bullet[bullet.type](bullet) //this attaches id if needed
         index = index || this.bullets.length; //so we can preserve ordering in collections.bullet array
-        this.bullets = this.bullets.slice(0, index).concat(bullet).concat(this.bullets.slice(index));
+        this.bullets.splice(index, 0, bullet);
         if (bullet.collections.indexOf(this.id) < 0) bullet.collections.push(this.id)
         return Promise.all([this.save(), bullet.save()])
             .catch(err => console.error('error ', err))

--- a/app/models/collection.js
+++ b/app/models/collection.js
@@ -32,23 +32,35 @@ class Collection {
 
     deserializeBullets(bulletInstances) {
         this.bullets = this.bullets.map(bulletId => {
-            const bullet = bulletInstances.find(b => b.id === bulletId);
-            return new Bullet[bullet.type](bullet);
+            let bullet = bulletInstances.find(b => b.id === bulletId);
+            bullet = new Bullet[bullet.type](bullet);
+            return bullet;
         });
         return this;
     }
 
     serializeBullets() {
-        if(this.bullets.every(b => typeof b !== "string")){
+        if (this.bullets.every(b => typeof b !== "string")) {
             this.bullets = this.bullets.map(bullet => bullet.id); //beforeSave, converts bullet instances to ids
         }
     }
 
-    addBullet(bullet, index) {
+    addBullet(bullet) {
         bullet = new Bullet[bullet.type](bullet) //this attaches id if needed
-        index = index || this.bullets.length; //so we can preserve ordering in collections.bullet array
-        this.bullets.splice(index, 0, bullet);
-        if (bullet.collections.indexOf(this.id) < 0) bullet.collections.push(this.id)
+        console.log(bullet, this.bullets);
+        if (this.bullets.find(b => b.id === bullet.id)) return; // make sure to check this!
+        this.bullets.push(bullet);
+        bullet.collections.push(this.id);
+        //add to other collections check
+        let search;
+        if (this.type === 'month-cal' || bullet.type === 'Event') search = { title: Moment(bullet.date).startOf('day').toISOString(), type: 'day' };
+        if (this.type === 'future') search = { title: this.title, type: 'month' };
+        if (search) {
+            Collection.fetchAll(search)
+                .then(c => c[0].addBullet(bullet))
+                .catch(err => console.error(err));
+        }
+
         return Promise.all([this.save(), bullet.save()])
             .catch(err => console.error('error ', err))
     }
@@ -62,7 +74,7 @@ class Collection {
     }
 
     save() {
-        const bulletInstances = this.bullets;
+        let bulletInstances = this.bullets;
         this.serializeBullets();
         return db.rel.save('collection', this).then(() => {
             this.bullets = bulletInstances;
@@ -71,24 +83,21 @@ class Collection {
     }
 
     static findOrReturn(props) {
-       return db.rel.find('collection', props.id)
-           .then(res => {
-               if (res.collections.length > 1) res.collections = [res.collections.find(c => c.id === props.id)]; //this is a hack to fix something wierd in PouchDB
-               if (!res.collections.length) return new Collection(props)
-               else return convertToInstances(res);
-           })
-           .catch(err => console.error(err));
-   }
+        return db.rel.find('collection', props.id)
+            .then(res => {
+                if (res.collections.length > 1) res.collections = [res.collections.find(c => c.id === props.id)]; //this is a hack to fix something wierd in PouchDB
+                if (!res.collections.length) return new Collection(props)
+                else return convertToInstances(res);
+            })
+            .catch(err => console.error(err));
+    }
 
     static fetchAll(props) {
         return db.rel.find('collection')
-            .then(res => {
-                if (!res.collections.length) return new Collection(props)
-                else return convertToInstances(res)
-            })
+            .then(res => convertToInstances(res))
             .then(collections => {
-               
-                if (props) return _.filter(collections, props);
+                if (props) collections = _.filter(collections, props);
+                if (!collections.length) return [new Collection(props)];
                 else return collections;
             })
             .catch(err => console.error('could not fetch all collections'));

--- a/app/scripts/_utils/date.factory.js
+++ b/app/scripts/_utils/date.factory.js
@@ -52,7 +52,7 @@ bulletApp.factory('DateFactory', function() {
 
     function getWeekday(date) {
         let weekday = Moment(date).isoWeekday();
-        weekday = Moment().isoWeekday(weekday).format('ddd')
+        weekday = Moment().isoWeekday(weekday).format('dd')
         return weekday;
     }
 

--- a/app/scripts/_utils/date.factory.js
+++ b/app/scripts/_utils/date.factory.js
@@ -47,7 +47,7 @@ bulletApp.factory('DateFactory', function() {
             day = Moment(day).add(1, 'days').toISOString();
             day = new Date(day);
         }
-        return dayArray.map(getWeekday);
+        return dayArray;
     }
 
     function getWeekday(date) {
@@ -62,6 +62,6 @@ bulletApp.factory('DateFactory', function() {
         monthCal: monthCal,
         splitCollections: splitCollections,
         today: today,
-        thisMonth: thisMonth
+        thisMonth: thisMonth,
     }
 })

--- a/app/scripts/_utils/date.factory.js
+++ b/app/scripts/_utils/date.factory.js
@@ -62,6 +62,6 @@ bulletApp.factory('DateFactory', function() {
         monthCal: monthCal,
         splitCollections: splitCollections,
         today: today,
-        thisMonth: thisMonth,
+        thisMonth: thisMonth
     }
 })

--- a/app/scripts/bullets/bullet.directive.js
+++ b/app/scripts/bullets/bullet.directive.js
@@ -11,15 +11,6 @@ bulletApp.directive('bullet', function () {
         },
         link: function (scope, element) {
 
-            scope.typeDict = {
-                "Task": "fa-circle-o", //fa-square-o
-                "Event": "fa-first-order",
-                "Note": "fa-long-arrow-right",
-                "Done": "fa-check-circle-o", //fa-check-square-o"
-                "Migrated": "fa-sign-out",
-                "Scheduled": "fa-angle-double-left"
-            };
-
             const OS = process.platform;
 
             function editBullet(e) {

--- a/app/scripts/bullets/bullet.template.html
+++ b/app/scripts/bullets/bullet.template.html
@@ -1,6 +1,7 @@
-
 <div class="row">
-	<bulleticon bullet="bullet" header="header"></bulleticon>
-	<div contenteditable class = "col-lg-10 col-md-10 col-sm-9 col-xs-9 bullet-text" ng-model="bullet.content" only-text="true" ng-class="{strikethrough: bullet.strike}">
-	</div>
+    <bullet-icon bullet="bullet" header="header"></bullet-icon>
+    <div class="col-lg-10 col-md-10 col-sm-9 col-xs-9 bullet-text" ng-class="{strikethrough: bullet.strike, new: !bullet.content.length}">
+        <div contenteditable ng-model="bullet.content" only-text="true"></div>
+    </div>
 </div>
+

--- a/app/scripts/bullets/bullet.template.html
+++ b/app/scripts/bullets/bullet.template.html
@@ -1,15 +1,6 @@
 
-<div ng-show="!header" class="row">
-	<bulleticon bullet="bullet"></bulleticon>
-	<div contenteditable class = "col-lg-11 col-md-11 col-sm-11 col-xs-11" ng-model="bullet.content" only-text="true" ng-class="{strikethrough: bullet.strike}">
-	</div>
-</div>
-
-<div ng-show="header" class="row">
-	<div class="col-lg-2 col-md-2 col-sm-3 col-xs-3">
-		<i>{{header}}</i>
-	</div>
-	<div class = "col-lg-10 col-md-10 col-sm-9 col-xs-9">
-		<span class="bullet-text" contenteditable ng-model="bullet.content" only-text="true" ng-class="{strikethrough: bullet.strike}"></span>
+<div class="row">
+	<bulleticon bullet="bullet" header="header"></bulleticon>
+	<div contenteditable class = "col-lg-10 col-md-10 col-sm-9 col-xs-9 bullet-text" ng-model="bullet.content" only-text="true" ng-class="{strikethrough: bullet.strike}">
 	</div>
 </div>

--- a/app/scripts/bullets/icon.directive.js
+++ b/app/scripts/bullets/icon.directive.js
@@ -4,7 +4,8 @@ bulletApp.directive('bulleticon', function () {
         restrict: 'E',
         templateUrl: 'scripts/bullets/icon.template.html',
         scope: {
-            bullet: '='
+            bullet: '=',
+            header: '='
         },
         link: function (scope, element) {
             scope.isNew = (scope.bullet) ? scope.bullet.content : false;

--- a/app/scripts/bullets/icon.directive.js
+++ b/app/scripts/bullets/icon.directive.js
@@ -1,5 +1,5 @@
 /*jshint esversion: 6*/
-bulletApp.directive('bulleticon', function () {
+bulletApp.directive('bulletIcon', function () {
     return {
         restrict: 'E',
         templateUrl: 'scripts/bullets/icon.template.html',

--- a/app/scripts/bullets/icon.template.html
+++ b/app/scripts/bullets/icon.template.html
@@ -1,3 +1,4 @@
 <div class="col-lg-1 col-md-1 col-sm-1 col-xs-1 bullet">
-    <i ng-show="isNew" class="fa fa-fw" ng-class="bullet.status === 'complete' ? typeDict['Done'] : typeDict[bullet.type]" ng-click="bullet.toggleDone()"></i>
+    <i ng-if="!header" ng-show="isNew" class="fa fa-fw" ng-class="bullet.status === 'complete' ? typeDict['Done'] : typeDict[bullet.type]" ng-click="bullet.toggleDone()"></i>
+    <span ng-if="header">{{header}}</span>
 </div>

--- a/app/scripts/collections/collection.directive.js
+++ b/app/scripts/collections/collection.directive.js
@@ -52,10 +52,6 @@ bulletApp.directive('collection', function($log, currentStates){
                   .catch($log.err);
               };
             }
-
-            
-            //if type is future also add bullet to {title: collection.title, type: 'month'}
-            //if a bullet is an event, we should add it to the right day collection.
         }
     };
 });

--- a/app/scripts/collections/collection.directive.js
+++ b/app/scripts/collections/collection.directive.js
@@ -52,6 +52,10 @@ bulletApp.directive('collection', function($log, currentStates){
                   .catch($log.err);
               };
             }
+
+            
+            //if type is future also add bullet to {title: collection.title, type: 'month'}
+            //if a bullet is an event, we should add it to the right day collection.
         }
     };
 });

--- a/app/scripts/collections/collection.template.html
+++ b/app/scripts/collections/collection.template.html
@@ -1,7 +1,7 @@
 <div class="col-lg-6 col-md-6 col-sm-12 col-xs-12">
     <h4 class="page-header" ng-class="{'text-muted': muted}">{{formattedTitle}}</h4>
     <div>
-        <bullet ng-repeat="bullet in collection.bullets" bullet="bullet" remove-fn="removeBullet(bullet)" add-fn="">
+        <bullet ng-repeat="bullet in collection.bullets track by $index" bullet="bullet" remove-fn="removeBullet(bullet)" add-fn="">
         </bullet>
         <bullet bullet="newBullet" remove-fn="removeBullet(newBullet)" add-fn="addBullet(newBullet)">
         </bullet>

--- a/app/scripts/log/log.template.html
+++ b/app/scripts/log/log.template.html
@@ -4,7 +4,7 @@
             <h1 class="page-header">{{title}}</h1>
             <button ng-click="prev6()">Go Back</button>
             <button ng-click="next6()">Go Forward</button>
-            <div ng-repeat="collection in collections">
+            <div ng-repeat="collection in collections track by collection.title">
                 <collection collection="collection"></collection>
             </div>
         </div>

--- a/app/scripts/month-cal/month.cal.directive.js
+++ b/app/scripts/month-cal/month.cal.directive.js
@@ -34,11 +34,7 @@ bulletApp.directive('monthCal', function($log) {
             };
             scope.addBullet = function(bullet) {
                 if (bullet.content && bullet.content.length > 0) {
-                    scope.collection.addBullet(bullet)
-                    .then(function() {
-                      scope.$evalAsync();
-                    })
-                    .catch($log.err);
+                    scope.collection.addBullet(bullet);
                 };
             }
         }

--- a/app/scripts/month-cal/month.cal.directive.js
+++ b/app/scripts/month-cal/month.cal.directive.js
@@ -1,6 +1,6 @@
 /*jshint esversion: 6*/
 
-bulletApp.directive('monthCal', function($log){
+bulletApp.directive('monthCal', function($log) {
     return {
         restrict: 'E',
         templateUrl: 'scripts/month-cal/month.cal.template.html',
@@ -9,49 +9,37 @@ bulletApp.directive('monthCal', function($log){
             numOfDays: '=',
         },
         link: function(scope) {
-          Collection.findOrReturn(scope.collection)
-          .then(function(res){
-              scope.collection = res;
-              scope.formattedTitle = Moment(scope.collection.title).format('MMM YY').toUpperCase();
-              scope.muted = false;
-              scope.$evalAsync();
-          })
-          .then(function () {
-            scope.bulletList = {}
-            scope.collection.bullets.forEach(bullet => {
-              scope.bulletList[Moment(bullet.date).date()] = bullet
-            })
-            scope.bulletList = scope.numOfDays.map((day, index) => {
-              if(scope.bulletList[index + 1]) return scope.bulletList[index + 1];
-              else return new Bullet.Task({
-                id: Moment().add(index, 'milliseconds').toISOString(),
-                date: Moment(scope.collection.title).add(index, 'days').toISOString(),
-                collections: [scope.collection.id]});
-            })
-          })
-          .catch($log.err);
+            scope.formattedTitle = Moment(scope.collection.title).format('MMMM YYYY').toUpperCase();
+            scope.muted = false; // still needed?
 
-            /**********************************************************
-            * This function will remove the bullet from the collection
-            * and then make sure the bullet is also removed from the
-            * local bullets array.
-            **********************************************************/
+            scope.bulletList = {};
+            scope.collection.bullets.forEach(bullet => {
+                scope.bulletList[Moment(bullet.date).date()] = bullet
+            });
+
+            scope.bulletList = scope.numOfDays.map((day, index) => {
+                if (scope.bulletList[index + 1]) return scope.bulletList[index + 1];
+                else return new Bullet.Task({
+                    date: day,
+                    collections: [scope.collection.id]
+                });
+            })
+
             scope.removeBullet = function(bullet) {
                 scope.collection.removeBullet(bullet)
-                .then(function(){
-                    scope.bullets = scope.bullets.filter(b => b.id !== bullet.id);
-                })
-                .catch($log.err);
+                    .then(function() {
+                        scope.bullets = scope.bullets.filter(b => b.id !== bullet.id);
+                    })
+                    .catch($log.err);
             };
             scope.addBullet = function(bullet) {
                 if (bullet.content && bullet.content.length > 0) {
-                  scope.collection.addBullet(bullet)
-                  .then(function(){
-                      scope.newBullet = new Bullet.Task()
-                      scope.$evalAsync()
-                  })
-                  .catch($log.err);
-              };
+                    scope.collection.addBullet(bullet)
+                    .then(function() {
+                      scope.$evalAsync();
+                    })
+                    .catch($log.err);
+                };
             }
         }
     };

--- a/app/scripts/month-cal/month.cal.directive.js
+++ b/app/scripts/month-cal/month.cal.directive.js
@@ -6,22 +6,14 @@ bulletApp.directive('monthCal', function($log) {
         templateUrl: 'scripts/month-cal/month.cal.template.html',
         scope: {
             collection: '=',
-            numOfDays: '=',
+            days: '=',
         },
         link: function(scope) {
             scope.formattedTitle = Moment(scope.collection.title).format('MMMM YYYY').toUpperCase();
-            scope.muted = false; // still needed?
-
-            scope.bulletList = {};
-            scope.collection.bullets.forEach(bullet => {
-                scope.bulletList[Moment(bullet.date).date()] = bullet
-            });
-
-            scope.bulletList = scope.numOfDays.map((day, index) => {
-                if (scope.bulletList[index + 1]) return scope.bulletList[index + 1];
-                else return new Bullet.Task({
-                    date: day,
-                    collections: [scope.collection.id]
+            
+            scope.bulletList = scope.days.map(day => {
+                return scope.collection.bullets.find(bullet => bullet.date === day) || new Bullet.Task({
+                    date: day
                 });
             })
 
@@ -32,6 +24,7 @@ bulletApp.directive('monthCal', function($log) {
                     })
                     .catch($log.err);
             };
+
             scope.addBullet = function(bullet) {
                 if (bullet.content && bullet.content.length > 0) {
                     scope.collection.addBullet(bullet);

--- a/app/scripts/month-cal/month.cal.template.html
+++ b/app/scripts/month-cal/month.cal.template.html
@@ -1,13 +1,13 @@
 <div class="col-lg-6 col-md-6 col-sm-12 col-xs-12">
     <h4 class="page-header">{{formattedTitle}}</h4>
-    <ul>
+
       <div ng-repeat="day in numOfDays track by $index">
         <bullet
-        header="{{$index+1}} {{day}}"
+        header="{{$index+1}} {{day | date: 'EEE'}}"
         bullet="bulletList[$index + '']"
         remove-fn="removeBullet(bulletList[$index + ''])"
         add-fn="addBullet(bulletList[$index + ''])"
         ></bullet>
       </div>
-    </ul>
+
 </div>

--- a/app/scripts/month-cal/month.cal.template.html
+++ b/app/scripts/month-cal/month.cal.template.html
@@ -1,12 +1,12 @@
 <div class="col-lg-6 col-md-6 col-sm-12 col-xs-12">
     <h4 class="page-header">{{formattedTitle}}</h4>
 
-      <div ng-repeat="day in numOfDays track by $index">
+      <div ng-repeat="bullet in bulletList track by $index">
         <bullet
-        header="{{$index+1}} {{day | date: 'EEE'}}"
-        bullet="bulletList[$index + '']"
-        remove-fn="removeBullet(bulletList[$index + ''])"
-        add-fn="addBullet(bulletList[$index + ''])"
+        header="{{$index+1}} {{bullet.date | date: 'EEE'}}"
+        bullet="bullet"
+        remove-fn="removeBullet(bullet)"
+        add-fn="addBullet(bullet)"
         ></bullet>
       </div>
 

--- a/app/scripts/monthlytracker/monthlytracker.controller.js
+++ b/app/scripts/monthlytracker/monthlytracker.controller.js
@@ -1,7 +1,7 @@
 /*jshint esversion: 6*/
 bulletApp.controller('MonthlyTrackerCtrl', function ($scope, collections, DateFactory, month) {
 
-    $scope.numOfDays = DateFactory.monthCal(month);
+    $scope.daysInMonth = DateFactory.monthCal(month);
     $scope.month = month;
     $scope.log = collections.find(i => i.type === "month") || new Collection(month, 'month');
     $scope.cal = collections.find(i => i.type === "month-cal") || new Collection(month, 'month-cal');

--- a/app/scripts/monthlytracker/monthlytracker.template.html
+++ b/app/scripts/monthlytracker/monthlytracker.template.html
@@ -1,6 +1,6 @@
 <div class="container">
     <div class="row">
-        <month-cal collection="cal" num-of-days="numOfDays"></month-cal>
+        <month-cal collection="cal" days="daysInMonth"></month-cal>
         <collection collection="log"></collection>
     </div>
 </div>

--- a/app/scss/main.scss
+++ b/app/scss/main.scss
@@ -13,7 +13,7 @@ html {
 }
 
 .fa {
-    font-size: 12px
+    font-size: 13px
 }
 
 .bullet-text {
@@ -21,11 +21,21 @@ html {
 }
 
 .bullet {
-    padding-right: 0;
+    padding: 3px;
     text-align: right;
-    font-size: 12px;
 }
 
+.new {
+    border-bottom: 1px solid #F5F5F5;
+}
+
+
+//not yet in use
+.new-collection:hover {
+    -webkit-box-shadow: 4px 20px 29px -4px rgba(0, 0, 0, 0.75);
+    -moz-box-shadow: 4px 20px 29px -4px rgba(0, 0, 0, 0.75);
+    box-shadow: 4px 20px 29px -4px rgba(0, 0, 0, 0.75);
+}
 
 // Sticky Footer
 html {

--- a/app/scss/main.scss
+++ b/app/scss/main.scss
@@ -1,6 +1,6 @@
 body,
 html {
-    font-family: proxima-nova, "Helvetica Neue", Helvetica, Arial, sans-serif;
+    font-family: "proxima-nova", "Helvetica Neue", Helvetica, Arial, sans-serif;
     line-height: 1.4;
     vertical-align: middle;
     font-size: 14px;
@@ -17,13 +17,15 @@ html {
 }
 
 .bullet-text {
-    padding-left: 0;
+    padding-left: 5px;
 }
 
 .bullet {
     padding-right: 0;
-    text-align: right
+    text-align: right;
+    font-size: 12px;
 }
+
 
 // Sticky Footer
 html {
@@ -34,7 +36,7 @@ html {
 body {
     /* Margin bottom by footer height */
     margin-bottom: 60px;
-    // -webkit-app-region: drag
+    -webkit-app-region: drag
 }
 
 .navbar {


### PR DESCRIPTION
- closes #67 which adds bullets to the right collections in Future Log and Month Cal
- **removes id assignment from the front end** and adds it as a 'before-save' functionality
- adds bullets to the right daily collection if the event is a date (we still need to add dates to every bullet)
- refactors bullet-template and bullet-icon template to be skinnier / smarter (though not close to done)
- refactors month-cal directive so that it is not doing a find or return, so that the daysInMonth array is actually an array of dates
- adds in "track by collection.title" or "track by $index" where its necessary
